### PR TITLE
Fixes the disconnect between focused element and enter hotkey (issue …

### DIFF
--- a/static/js/hotkey.js
+++ b/static/js/hotkey.js
@@ -321,13 +321,6 @@ exports.process_enter_key = function (e) {
         return false;
     }
 
-    // This handles when pressing enter while looking at drafts.
-    // It restores draft that is focused.
-    if (overlays.drafts_open()) {
-        drafts.drafts_handle_events(e, "enter");
-        return true;
-    }
-
     // If we're on a button or a link and have pressed enter, let the
     // browser handle the keypress
     //

--- a/static/templates/draft.handlebars
+++ b/static/templates/draft.handlebars
@@ -33,11 +33,11 @@
                 <div class="messagebox-content">
                     <div class="message_top_line">
                         <div class="draft_controls">
-                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Enter)"></i>
+                            <i class="icon-vector-large icon-vector-pencil restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)"></i>
                             <i class="icon-vector-large icon-vector-trash delete-draft" data-toggle="tooltip" title="{{t 'Delete draft' }} (Backspace)"></i>
                         </div>
                     </div>
-                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Enter)">{{{content}}}</div>
+                    <div class="message_content restore-draft" data-toggle="tooltip" title="{{t 'Restore draft' }} (Click)">{{{content}}}</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
…#9093)

<!-- What's this PR for?  (Just a link to an issue is fine.) -->
https://github.com/zulip/zulip/issues/9093

**Testing Plan:** <!-- How have you tested? -->
Tested on the front end environment

**GIFs or Screenshots:** <!-- If a UI change.  See:
  https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html
  -->
![zulip9093fixgif](https://user-images.githubusercontent.com/27150975/38957708-482439e0-4329-11e8-83fa-70a0e4006bd6.gif)


<!-- Also be sure to make clear, coherent commits:
  https://zulip.readthedocs.io/en/latest/contributing/version-control.html
  -->